### PR TITLE
🎨 Palette: Enhance Editor accessibility and keyboard navigation

### DIFF
--- a/components/editor/components/panels/ColorizerTab.tsx
+++ b/components/editor/components/panels/ColorizerTab.tsx
@@ -35,7 +35,7 @@ export const ColorizerTab = ({
         onClick={onColorize}
         disabled={!hasImage}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200",
+          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2",
           hasImage
             ? "cursor-pointer hover:brightness-110 active:scale-[0.98]"
             : "cursor-not-allowed opacity-25"
@@ -61,7 +61,7 @@ export const ColorizerTab = ({
       {hasColorized && (
         <button
           onClick={onDownload}
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-medium text-white/70 transition-all duration-200 hover:border-white/20 hover:bg-white/10 hover:text-white active:scale-[0.98]"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-medium text-white/70 transition-all duration-200 hover:border-white/20 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 active:scale-[0.98]"
         >
           <Download className="size-4" />
           Download Colorized

--- a/components/editor/components/panels/EditorQueuePanel.tsx
+++ b/components/editor/components/panels/EditorQueuePanel.tsx
@@ -82,8 +82,17 @@ export const EditorQueuePanel = ({
             return (
               <div
                 key={file.name + index}
+                tabIndex={0}
+                role="button"
+                aria-label={`Select ${file.name}`}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    onSelectImage(url, file.name)
+                  }
+                }}
                 className={cn(
-                  "group relative h-24 min-h-24 cursor-pointer overflow-hidden rounded-xl border-2 transition-all duration-200",
+                  "group relative h-24 min-h-24 cursor-pointer overflow-hidden rounded-xl border-2 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
                   isSelected ? "border-2 shadow-lg" : "border-transparent"
                 )}
                 style={
@@ -91,8 +100,12 @@ export const EditorQueuePanel = ({
                     ? {
                       borderColor: accentColor,
                       boxShadow: `0 0 16px ${accentColor}30`,
-                    }
-                    : { borderColor: "rgba(255,255,255,0.06)" }
+                      "--tw-ring-color": accentColor,
+                    } as any
+                    : {
+                      borderColor: "rgba(255,255,255,0.06)",
+                      "--tw-ring-color": "rgba(255,255,255,0.4)",
+                    } as any
                 }
               >
                 <img
@@ -119,10 +132,14 @@ export const EditorQueuePanel = ({
 
                 {/* Remove button */}
                 <Button
-                  onClick={() => onRemoveFile(file)}
-                  className="absolute right-1.5 top-1.5 size-6 rounded-full bg-black/60 p-0 text-white/70 opacity-0 transition-all hover:bg-black/80 hover:text-white group-hover:opacity-100"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onRemoveFile(file)
+                  }}
+                  className="absolute right-1.5 top-1.5 z-10 size-6 rounded-full bg-black/60 p-0 text-white/70 opacity-0 transition-all hover:bg-black/80 hover:text-white group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2"
                   variant="ghost"
                   size="icon"
+                  aria-label={`Remove ${file.name}`}
                   title={`Remove ${file.name}`}
                 >
                   <Trash className="size-3" />

--- a/components/editor/components/panels/RemoverTab.tsx
+++ b/components/editor/components/panels/RemoverTab.tsx
@@ -47,10 +47,11 @@ export const RemoverTab = ({
 
           <button
             role="switch"
+            aria-label="Toggle solid background"
             aria-checked={applyBgColor}
             onClick={onToggleBgColor}
             className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none"
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2"
             )}
             style={{
               backgroundColor: applyBgColor
@@ -91,7 +92,7 @@ export const RemoverTab = ({
         onClick={onRemove}
         disabled={!hasImage}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-semibold text-white transition-all duration-200",
+          "flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-semibold text-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2",
           hasImage
             ? "cursor-pointer hover:opacity-90 active:scale-[0.98]"
             : "cursor-not-allowed opacity-30"

--- a/components/editor/components/panels/UpscalerTab.tsx
+++ b/components/editor/components/panels/UpscalerTab.tsx
@@ -58,7 +58,7 @@ export const UpscalerTab = ({
                 key={mk}
                 onClick={() => onUpscalerSettingsChange(mk)}
                 className={cn(
-                  "flex items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-all duration-200",
+                  "flex items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2",
                   !isSelected &&
                     "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.1] hover:bg-white/[0.06]"
                 )}
@@ -132,7 +132,7 @@ export const UpscalerTab = ({
         onClick={onUpscale}
         disabled={!hasImage}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200",
+          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2",
           hasImage
             ? "cursor-pointer hover:brightness-110 active:scale-[0.98]"
             : "cursor-not-allowed opacity-25"
@@ -158,7 +158,7 @@ export const UpscalerTab = ({
       {hasUpscaled && (
         <button
           onClick={onDownload}
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-medium text-white/70 transition-all duration-200 hover:border-white/20 hover:bg-white/10 hover:text-white active:scale-[0.98]"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-medium text-white/70 transition-all duration-200 hover:border-white/20 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 focus-visible:ring-offset-2 active:scale-[0.98]"
         >
           <Download className="size-4" />
           Download Upscaled


### PR DESCRIPTION
This PR implements several micro-UX and accessibility enhancements to the Editor interface, focusing on keyboard navigation and screen reader support.

### 💡 What
- **Interactive Focus States**: Added visible focus rings to all primary buttons and switches in the Remover, Upscaler, and Colorizer tabs.
- **Keyboard-Navigable Queue**: The image queue thumbnails are now fully accessible via keyboard. Users can tab through images and select them using Enter or Space.
- **ARIA Enhancements**: Added descriptive labels to buttons that previously only had icons or lacked explicit context for screen readers.

### 🎯 Why
These changes ensure that users who rely on keyboard navigation or assistive technologies can effectively use the image processing tools. It also provides clearer visual feedback during navigation, improving the overall polish of the interface.

### ♿ Accessibility
- Fixed missing `aria-label` on the background toggle switch.
- Improved focus visibility for all interactive elements in the right panel.
- Added keyboard interaction support for the queue list (previously only clickable).
- Ensured hidden-on-hover actions (like "Remove" from queue) are visible when they receive keyboard focus.

---
*PR created automatically by Jules for task [10683132967099644244](https://jules.google.com/task/10683132967099644244) started by @yossTheDev*