### PR TITLE
🎨 Palette: Improve editor accessibility and keyboard navigation

### DIFF
--- a/components/editor/components/panels/EditorQueuePanel.tsx
+++ b/components/editor/components/panels/EditorQueuePanel.tsx
@@ -5,6 +5,11 @@ import type { ImageSetting } from "@/types/image-settings"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
   FileInput,
   FileUploader,
   FileUploaderContent,
@@ -82,16 +87,26 @@ export const EditorQueuePanel = ({
             return (
               <div
                 key={file.name + index}
+                role="button"
+                tabIndex={0}
+                aria-label={`Select ${file.name}`}
+                onClick={() => onSelectImage(url, file.name)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    onSelectImage(url, file.name)
+                  }
+                }}
                 className={cn(
-                  "group relative h-24 min-h-24 cursor-pointer overflow-hidden rounded-xl border-2 transition-all duration-200",
+                  "group relative h-24 min-h-24 cursor-pointer overflow-hidden rounded-xl border-2 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
                   isSelected ? "border-2 shadow-lg" : "border-transparent"
                 )}
                 style={
                   isSelected
                     ? {
-                      borderColor: accentColor,
-                      boxShadow: `0 0 16px ${accentColor}30`,
-                    }
+                        borderColor: accentColor,
+                        boxShadow: `0 0 16px ${accentColor}30`,
+                      }
                     : { borderColor: "rgba(255,255,255,0.06)" }
                 }
               >
@@ -99,7 +114,6 @@ export const EditorQueuePanel = ({
                   className="h-full w-full rounded-[10px] object-cover"
                   alt={`Queue item ${index + 1}: ${file.name}`}
                   src={url}
-                  onClick={() => onSelectImage(url, file.name)}
                 />
 
                 {/* Gradient overlay */}
@@ -118,15 +132,25 @@ export const EditorQueuePanel = ({
                 )}
 
                 {/* Remove button */}
-                <Button
-                  onClick={() => onRemoveFile(file)}
-                  className="absolute right-1.5 top-1.5 size-6 rounded-full bg-black/60 p-0 text-white/70 opacity-0 transition-all hover:bg-black/80 hover:text-white group-hover:opacity-100"
-                  variant="ghost"
-                  size="icon"
-                  title={`Remove ${file.name}`}
-                >
-                  <Trash className="size-3" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onRemoveFile(file)
+                      }}
+                      className="absolute right-1.5 top-1.5 size-6 rounded-full bg-black/60 p-0 text-white/70 opacity-0 transition-all hover:bg-black/80 hover:text-white group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Remove ${file.name} from queue`}
+                    >
+                      <Trash className="size-3" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Remove from queue</p>
+                  </TooltipContent>
+                </Tooltip>
               </div>
             )
           })}

--- a/components/editor/components/panels/RemoverTab.tsx
+++ b/components/editor/components/panels/RemoverTab.tsx
@@ -74,15 +74,17 @@ export const RemoverTab = ({
             <input
               type="color"
               value={bgColor}
+              aria-label="Background color picker"
               onChange={(e) => onBgColorChange((e.target as any).value)}
-              className="size-9 cursor-pointer rounded-lg border border-white/10 bg-transparent p-0.5"
+              className="size-9 cursor-pointer rounded-lg border border-white/10 bg-transparent p-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
             />
             <input
               type="text"
               value={bgColor}
               maxLength={7}
+              aria-label="Background color hex code"
               onChange={(e) => onBgColorChange((e.target as any).value)}
-              className="flex-1 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 font-mono text-xs text-white/80 focus:outline-none focus:border-white/20"
+              className="flex-1 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 font-mono text-xs text-white/80 focus:outline-none focus:border-white/20 focus-visible:ring-2 focus-visible:ring-white/20"
             />
           </div>
         )}


### PR DESCRIPTION
I have implemented several micro-UX improvements to enhance accessibility and keyboard navigation within the editor:

1.  **Image Queue Accessibility**:
    *   Made queue items focusable (`tabIndex={0}`) and added `role="button"`.
    *   Added `onKeyDown` handlers to support selection via `Enter` or `Space` keys.
    *   Added descriptive `aria-label` to queue items.
    *   Wrapped the "Remove" button in a `Tooltip` and added a clear `aria-label`.
    *   Ensured the "Remove" button remains visible when its parent item is focused by using `group-focus-within`.

2.  **Color Picker Accessibility**:
    *   Added `aria-label` to both the color picker and the hex code input in the Background Removal tab.
    *   Added `focus-visible` ring styles to match the design system.

These changes make the application more inclusive for users relying on screen readers or keyboard navigation.

---
*PR created automatically by Jules for task [18006901917523170486](https://jules.google.com/task/18006901917523170486) started by @yossTheDev*