### PR TITLE
🎨 Palette: Enhance accessibility with visible focus rings and ARIA labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.3] - 2025-05-15
+### Fixed
+- 🎨 **Palette**: Improved keyboard accessibility by adding visible focus states to tool switchers, model selector, and toggle switches.
+- Added `aria-label` to the version/changelog button for better screen reader support.

--- a/components/editor/components/panels/ColorizerTab.tsx
+++ b/components/editor/components/panels/ColorizerTab.tsx
@@ -52,7 +52,7 @@ export const ColorizerTab = ({
         onClick={onColorize}
         disabled={!hasImage}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200",
+          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
           hasImage
             ? "cursor-pointer hover:brightness-110 active:scale-[0.98]"
             : "cursor-not-allowed opacity-25"

--- a/components/editor/components/panels/EditorRightPanel.tsx
+++ b/components/editor/components/panels/EditorRightPanel.tsx
@@ -118,7 +118,7 @@ export const EditorRightPanel = ({
               key={key}
               onClick={() => onToolChange(key)}
               className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-medium transition-all duration-200"
+                "flex flex-1 items-center justify-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
               )}
               style={
                 activeTool === key
@@ -157,7 +157,7 @@ export const EditorRightPanel = ({
               <>
                 <button
                   onClick={() => setModelDialogOpen(true)}
-                  className="group flex w-full items-center justify-between rounded-xl border border-white/[0.07] bg-white/[0.03] px-3.5 py-3 text-left transition-all duration-200 hover:border-white/[0.14] hover:bg-white/[0.06]"
+                  className="group flex w-full items-center justify-between rounded-xl border border-white/[0.07] bg-white/[0.03] px-3.5 py-3 text-left transition-all duration-200 hover:border-white/[0.14] hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
                 >
                   <div className="flex flex-col gap-0.5">
                     <span className="text-[9px] font-semibold uppercase tracking-[0.15em] text-white/30">

--- a/components/editor/components/panels/RemoverTab.tsx
+++ b/components/editor/components/panels/RemoverTab.tsx
@@ -52,7 +52,7 @@ export const RemoverTab = ({
             aria-checked={applyBgColor}
             onClick={onToggleBgColor}
             className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none"
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
             )}
             style={{
               backgroundColor: applyBgColor
@@ -95,7 +95,7 @@ export const RemoverTab = ({
         onClick={onRemove}
         disabled={!hasImage}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-semibold text-white transition-all duration-200",
+          "flex w-full items-center justify-center gap-2 rounded-xl py-2.5 text-sm font-semibold text-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
           hasImage
             ? "cursor-pointer hover:opacity-90 active:scale-[0.98]"
             : "cursor-not-allowed opacity-30"

--- a/components/editor/components/panels/UpscalerTab.tsx
+++ b/components/editor/components/panels/UpscalerTab.tsx
@@ -75,7 +75,7 @@ export const UpscalerTab = ({
                 key={mk}
                 onClick={() => onUpscalerSettingsChange(mk)}
                 className={cn(
-                  "flex items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-all duration-200",
+                  "flex items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
                   !isSelected &&
                   "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.1] hover:bg-white/[0.06]"
                 )}
@@ -149,7 +149,7 @@ export const UpscalerTab = ({
         onClick={onUpscale}
         disabled={!hasImage}
         className={cn(
-          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200",
+          "flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20",
           hasImage
             ? "cursor-pointer hover:brightness-110 active:scale-[0.98]"
             : "cursor-not-allowed opacity-25"
@@ -175,7 +175,7 @@ export const UpscalerTab = ({
       {hasUpscaled && (
         <button
           onClick={onDownload}
-          className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-medium text-white/70 transition-all duration-200 hover:border-white/20 hover:bg-white/10 hover:text-white active:scale-[0.98]"
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.05] px-4 py-2.5 text-sm font-medium text-white/70 transition-all duration-200 hover:border-white/20 hover:bg-white/10 hover:text-white active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
         >
           <Download className="size-4" />
           Download Upscaled

--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -488,12 +488,13 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
         <div className="pointer-events-auto absolute top-4 left-4 z-20 flex gap-2">
           <button
             onClick={() => setShowChangelog(true)}
-            className="rounded-xl border border-white/10 bg-white/[0.06] px-3 py-1.5 text-xs font-medium text-white/50 shadow-2xl backdrop-blur-2xl transition-all hover:bg-white/10 hover:text-white"
+            className="rounded-xl border border-white/10 bg-white/[0.06] px-3 py-1.5 text-xs font-medium text-white/50 shadow-2xl backdrop-blur-2xl transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
             style={{
               boxShadow: `0 8px 32px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.06), 0 0 40px ${accentColor}10`,
               color: accentColor,
             }}
             title="View changelog"
+            aria-label="View changelog"
           >
             v{APP_VERSION}
           </button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-template",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This PR implements a series of micro-UX improvements focused on accessibility and keyboard navigation.

### 💡 What
- Added `focus-visible:ring-2 focus-visible:ring-white/20` to multiple interactive elements including tool tabs, model selection buttons, and main action buttons.
- Replaced `focus-visible:outline-none` with visible focus indicators on toggle switches.
- Added `aria-label="View changelog"` to the version indicator button.
- Bumped version to `0.0.3` and added a `CHANGELOG.md` entry.

### 🎯 Why
Keyboard users currently have no visual indication of which element is focused in several parts of the editor. These changes ensure that the application is navigable and usable for everyone.

### ♿ Accessibility
- Fixed missing focus indicators on key interactive elements.
- Improved screen reader support for the version button.

### 📄 Changelog
Updated `CHANGELOG.md` to document these accessibility improvements.

---
*PR created automatically by Jules for task [17327144002408553885](https://jules.google.com/task/17327144002408553885) started by @yossTheDev*