### PR TITLE
🎨 Palette: Keyboard Shortcuts & Editor Polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2026-04-21 - [Radix UI Tooltip & Disabled Buttons]
+**Learning:** Radix UI `TooltipTrigger` (and standard HTML tooltips) does not reliably trigger when wrapping a `disabled` button because disabled elements don't fire pointer events.
+**Action:** Wrap the `disabled` button in a container element (like a `div` or `span`) that is still capable of receiving hover/pointer events to ensure the tooltip is displayed even when the action is unavailable.
+
+## 2026-04-21 - [Keyboard Affordances in Browser Tools]
+**Learning:** For complex, creative tools that run in the browser, users often expect professional-grade keyboard shortcuts (like zoom) to feel like native desktop apps.
+**Action:** Always pair keyboard shortcuts with visual hints in tooltips to improve discoverability and reduce the cognitive load of switching between mouse and keyboard.

--- a/components/editor/components/EditorToolbar.tsx
+++ b/components/editor/components/EditorToolbar.tsx
@@ -55,7 +55,7 @@ export const EditorToolbar = ({
               onClick={onProcess}
               size="icon"
               variant="ghost"
-              aria-label="Process all images in queue"
+              aria-label="Process all images in queue (Ctrl + Enter)"
               className={cn(
                 "size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
               )}
@@ -64,7 +64,7 @@ export const EditorToolbar = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Process all images</p>
+            <p>Process all images <span className="ml-1 text-white/40">(Ctrl + Enter)</span></p>
           </TooltipContent>
         </Tooltip>
 
@@ -94,41 +94,58 @@ export const EditorToolbar = ({
         {/* Zoom in */}
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              onClick={onZoomIn}
-              size="icon"
-              variant="ghost"
-              aria-label="Zoom in"
-              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
-            >
-              <ZoomIn className="size-4" />
-            </Button>
+            <div className="flex h-8 items-center">
+              <Button
+                onClick={onZoomIn}
+                disabled={zoom >= 3}
+                size="icon"
+                variant="ghost"
+                aria-label="Zoom in (Ctrl +)"
+                className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white disabled:opacity-20"
+              >
+                <ZoomIn className="size-4" />
+              </Button>
+            </div>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Zoom in</p>
+            <p>Zoom in <span className="ml-1 text-white/40">(Ctrl +)</span></p>
           </TooltipContent>
         </Tooltip>
 
-        {/* Zoom level indicator */}
-        <span className="w-12 text-center text-xs text-white/50">
-          {Math.round(zoom * 100)}%
-        </span>
+        {/* Zoom level indicator (also resets zoom) */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onZoomReset}
+              className="w-12 rounded-md text-center text-xs font-medium text-white/40 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
+              aria-label={`Current zoom ${Math.round(zoom * 100)}%. Click to reset.`}
+            >
+              {Math.round(zoom * 100)}%
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Reset zoom <span className="ml-1 text-white/40">(Ctrl 0)</span></p>
+          </TooltipContent>
+        </Tooltip>
 
         {/* Zoom out */}
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              onClick={onZoomOut}
-              size="icon"
-              variant="ghost"
-              aria-label="Zoom out"
-              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
-            >
-              <ZoomOut className="size-4" />
-            </Button>
+            <div className="flex h-8 items-center">
+              <Button
+                onClick={onZoomOut}
+                disabled={zoom <= 0.5}
+                size="icon"
+                variant="ghost"
+                aria-label="Zoom out (Ctrl -)"
+                className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white disabled:opacity-20"
+              >
+                <ZoomOut className="size-4" />
+              </Button>
+            </div>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Zoom out</p>
+            <p>Zoom out <span className="ml-1 text-white/40">(Ctrl -)</span></p>
           </TooltipContent>
         </Tooltip>
 
@@ -139,14 +156,14 @@ export const EditorToolbar = ({
               onClick={onZoomReset}
               size="icon"
               variant="ghost"
-              aria-label="Reset zoom"
+              aria-label="Reset zoom (Ctrl 0)"
               className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
             >
               <ScanEye className="size-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Reset zoom</p>
+            <p>Reset zoom <span className="ml-1 text-white/40">(Ctrl 0)</span></p>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -29,7 +29,7 @@ import type { ActiveTool, ModelKey, UpscalerModelKey } from "./types"
 
 const VALID_TOOLS: ActiveTool[] = ["remover", "upscaler", "colorizer"]
 const VALID_MODELS = Object.keys(MODELS) as ModelKey[]
-const APP_VERSION = "1.1.0"
+const APP_VERSION = "1.1.2"
 
 interface EditorProps {
   initialTool?: ActiveTool
@@ -176,6 +176,8 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
     setZoom(1)
   }, [])
 
+
+
   // Background composite
   const maybeComposite = useCallback(
     async (blob: Blob): Promise<Blob> => {
@@ -188,55 +190,6 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
     },
     [applyBgColor, bgColor]
   )
-
-  // Remove background
-  const remove = useCallback(async () => {
-    if (!queue.imageData) return
-
-    const start = performance.now()
-    openDialog("Starting…")
-
-    try {
-      const imgEl = await loadImage(queue.imageData)
-      const quality = 0.85 // Use standard quality during processing
-      const rawBlob = await onnx.runInference(
-        imgEl,
-        selectedModel,
-        updateDialog,
-        quality
-      )
-      const blob = await maybeComposite(rawBlob)
-      const url = URL.createObjectURL(blob)
-
-      queue.setResultsData((prev) => [
-        ...prev.filter((r) => r.name !== queue.selectedImage),
-        { data: blob, name: queue.selectedImage! },
-      ])
-      queue.setResultData(url)
-      triggerDust()
-
-      sendGAEvent({ event: "remove-background", value: "success" })
-      const elapsed = Math.floor((performance.now() - start) / 1000)
-      const { toast } = await import("sonner")
-      toast.success(`🚀 Done in ${elapsed} s`)
-    } catch (err) {
-      console.error("[remove]", err)
-      onnx.setModelStatus("error")
-      const { toast } = await import("sonner")
-      toast.error("Background removal failed.")
-    } finally {
-      closeDialog()
-    }
-  }, [
-    queue,
-    onnx,
-    selectedModel,
-    updateDialog,
-    openDialog,
-    closeDialog,
-    maybeComposite,
-    triggerDust,
-  ])
 
   // Batch process
   const process = useCallback(async () => {
@@ -285,6 +238,55 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
       console.error("[process]", err)
       const { toast } = await import("sonner")
       toast.error("Batch processing failed.")
+    } finally {
+      closeDialog()
+    }
+  }, [
+    queue,
+    onnx,
+    selectedModel,
+    updateDialog,
+    openDialog,
+    closeDialog,
+    maybeComposite,
+    triggerDust,
+  ])
+
+  // Remove background
+  const remove = useCallback(async () => {
+    if (!queue.imageData) return
+
+    const start = performance.now()
+    openDialog("Starting…")
+
+    try {
+      const imgEl = await loadImage(queue.imageData)
+      const quality = 0.85 // Use standard quality during processing
+      const rawBlob = await onnx.runInference(
+        imgEl,
+        selectedModel,
+        updateDialog,
+        quality
+      )
+      const blob = await maybeComposite(rawBlob)
+      const url = URL.createObjectURL(blob)
+
+      queue.setResultsData((prev) => [
+        ...prev.filter((r) => r.name !== queue.selectedImage),
+        { data: blob, name: queue.selectedImage! },
+      ])
+      queue.setResultData(url)
+      triggerDust()
+
+      sendGAEvent({ event: "remove-background", value: "success" })
+      const elapsed = Math.floor((performance.now() - start) / 1000)
+      const { toast } = await import("sonner")
+      toast.success(`🚀 Done in ${elapsed} s`)
+    } catch (err) {
+      console.error("[remove]", err)
+      onnx.setModelStatus("error")
+      const { toast } = await import("sonner")
+      toast.error("Background removal failed.")
     } finally {
       closeDialog()
     }
@@ -373,6 +375,32 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
       closeDialog()
     }
   }, [queue, openDialog, onnx, colorizerModel, updateDialog, closeDialog])
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
+      const isMod = e.ctrlKey || e.metaKey
+
+      if (isMod) {
+        if (e.key === "=" || e.key === "+") {
+          e.preventDefault()
+          handleZoomIn()
+        } else if (e.key === "-") {
+          e.preventDefault()
+          handleZoomOut()
+        } else if (e.key === "0") {
+          e.preventDefault()
+          handleZoomReset()
+        } else if (e.key === "Enter") {
+          e.preventDefault()
+          process()
+        }
+      }
+    }
+
+    globalThis.addEventListener("keydown", handleKeyDown)
+    return () => globalThis.removeEventListener("keydown", handleKeyDown)
+  }, [handleZoomIn, handleZoomOut, handleZoomReset, process])
 
   // Download
   const handleDownload = useCallback(async () => {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.2] - 2026-04-21
+
+### ✨ Added
+- 🎨 **Palette**: Implemented keyboard shortcuts for essential editor actions:
+  - `Ctrl/Cmd +` or `Ctrl/Cmd =` for Zoom In
+  - `Ctrl/Cmd -` for Zoom Out
+  - `Ctrl/Cmd 0` for Reset Zoom
+  - `Ctrl/Cmd + Enter` for Process All (Batch processing)
+
+### 🧠 Improved
+- 🎨 **Palette**: Added keyboard shortcut hints to tooltips in the Editor Toolbar.
+- 🎨 **Palette**: Zoom buttons now visually indicate when limits (50% and 300%) are reached by disabling.
+- 🎨 **Palette**: The zoom level indicator is now an interactive button that allows resetting the zoom to 100%.
+- 🎨 **Palette**: Enhanced accessibility by ensuring tooltips remain functional for disabled buttons.
+
+---
+
 ## [1.1.1] - Some Stability Fixes
 
 ### 🐛 Fixed


### PR DESCRIPTION
This PR introduces several micro-UX improvements to the editor to make it feel more professional and accessible:

1. **Keyboard Shortcuts**: Users can now use standard `Ctrl/Cmd` shortcuts for zooming (`+`, `-`, `0`) and batch processing (`Enter`).
2. **Toolbar Polish**:
   - Added shortcut hints to tooltips for better discoverability.
   - The zoom level indicator is now a clickable button that resets zoom to 100%.
   - Zoom buttons are disabled at their respective limits (50% and 300%) with a visual opacity change, while still maintaining functional tooltips via a wrapper element.
3. **Documentation**:
   - Updated the project's `CHANGELOG.md` following the established versioning protocol.
   - Initialized `palette.md` in the `.Jules` directory to capture critical UX and accessibility learnings.

Verified with Playwright scripts and production build.

---
*PR created automatically by Jules for task [6483438671875351298](https://jules.google.com/task/6483438671875351298) started by @yossTheDev*