### PR TITLE
🎨 Palette: Keyboard Shortcuts & Tooltip Enhancements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - Keyboard Shortcuts for Editor Accessibility
+**Learning:** Adding keyboard shortcuts for frequent actions (zoom, batch process) significantly improves accessibility and workflow efficiency. Informing users of these shortcuts via tooltips ensures discoverability.
+**Action:** Always consider keyboard shortcuts for primary editor actions and reflect them in tooltips using the (Ctrl + [Key]) convention.
+
+## 2025-05-15 - TypeScript & Global Event Listeners
+**Learning:** In this project's Next.js setup, global event listeners should use `globalThis` instead of `window` to pass type checking. Additionally, `useEffect` hooks using non-hoisted functions (like `useCallback` results) must be placed after those functions to avoid block-scoped variable errors.
+**Action:** Use `globalThis` and place shortcut hooks at the bottom of the component logic.

--- a/components/editor/components/EditorToolbar.tsx
+++ b/components/editor/components/EditorToolbar.tsx
@@ -2,12 +2,12 @@ import { Download, LoaderIcon, ScanEye, ZoomIn, ZoomOut } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { Icons } from "@/components/icons"
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { Icons } from "@/components/icons"
 
 interface EditorToolbarProps {
   canDownload: boolean
@@ -64,7 +64,7 @@ export const EditorToolbar = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Process all images</p>
+            <p>Process all images (Ctrl + Enter)</p>
           </TooltipContent>
         </Tooltip>
 
@@ -105,7 +105,7 @@ export const EditorToolbar = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Zoom in</p>
+            <p>Zoom in (Ctrl +)</p>
           </TooltipContent>
         </Tooltip>
 
@@ -128,7 +128,7 @@ export const EditorToolbar = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Zoom out</p>
+            <p>Zoom out (Ctrl -)</p>
           </TooltipContent>
         </Tooltip>
 
@@ -146,7 +146,7 @@ export const EditorToolbar = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Reset zoom</p>
+            <p>Reset zoom (Ctrl 0)</p>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -5,8 +5,8 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { sendGAEvent } from "@next/third-parties/google"
 
-import { EditorCanvas } from "./components/EditorCanvas"
 import { ChangelogDialog } from "./components/ChangelogDialog"
+import { EditorCanvas } from "./components/EditorCanvas"
 import { EditorProcessingDialog } from "./components/EditorProcessingDialog"
 import { EditorToolbar } from "./components/EditorToolbar"
 import { MobileRestriction } from "./components/MobileRestriction"
@@ -52,9 +52,8 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
   const [activeTool, setActiveTool] = useState<ActiveTool>(initialTool)
   const [selectedModel, setSelectedModel] =
     useState<ModelKey>("ormbg_quantized")
-  const [upscalerModel, setUpscalerModel] = useState<ModelKey>(
-    "swin2sr_quantized"
-  )
+  const [upscalerModel, setUpscalerModel] =
+    useState<ModelKey>("swin2sr_quantized")
   const [colorizerModel, setColorizerModel] = useState<ModelKey>(
     "deoldify_artistic_quantized"
   )
@@ -108,8 +107,8 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
       activeTool === "remover"
         ? selectedModel
         : activeTool === "upscaler"
-          ? upscalerModel
-          : colorizerModel
+        ? upscalerModel
+        : colorizerModel
     isModelCached(currentModel)
       .then((cached) => onnx.setModelStatus(cached ? "ready" : "idle"))
       .catch(() => onnx.setModelStatus("idle"))
@@ -137,8 +136,8 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
         tool === "remover"
           ? selectedModel
           : tool === "upscaler"
-            ? upscalerModel
-            : colorizerModel
+          ? upscalerModel
+          : colorizerModel
       pushUrl(tool, model)
     },
     [selectedModel, upscalerModel, colorizerModel, pushUrl]
@@ -388,7 +387,12 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
 
       const link = (globalThis as any).document.createElement("a")
       link.href = URL.createObjectURL(convertedBlob)
-      const ext = format === "image/webp" ? "webp" : format === "image/jpeg" ? "jpg" : "png"
+      const ext =
+        format === "image/webp"
+          ? "webp"
+          : format === "image/jpeg"
+          ? "jpg"
+          : "png"
       link.download = `removerized-upscaled-${Date.now()}.${ext}`
       link.click()
       return
@@ -406,7 +410,12 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
 
       const link = (globalThis as any).document.createElement("a")
       link.href = URL.createObjectURL(convertedBlob)
-      const ext = format === "image/webp" ? "webp" : format === "image/jpeg" ? "jpg" : "png"
+      const ext =
+        format === "image/webp"
+          ? "webp"
+          : format === "image/jpeg"
+          ? "jpg"
+          : "png"
       link.download = `removerized-colorized-${Date.now()}.${ext}`
       link.click()
       return
@@ -419,25 +428,67 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
       const quality = (setting?.quality ?? 80) / 100
 
       // Convert format
-      const convertedBlob = await convertImageFormat(result.data, format, quality)
+      const convertedBlob = await convertImageFormat(
+        result.data,
+        format,
+        quality
+      )
 
       const link = (globalThis as any).document.createElement("a")
       link.href = URL.createObjectURL(convertedBlob)
-      const ext = format === "image/webp" ? "webp" : format === "image/jpeg" ? "jpg" : "png"
+      const ext =
+        format === "image/webp"
+          ? "webp"
+          : format === "image/jpeg"
+          ? "jpg"
+          : "png"
 
       const nameWithoutExt = result.name.replace(/\.[^/.]+$/, "")
       link.download = `${nameWithoutExt}.${ext}`
       link.click()
     }
-  }, [activeTool, upscaledData, colorizedData, queue.resultsData, queue.settings, queue.selectedImage])
+  }, [
+    activeTool,
+    upscaledData,
+    colorizedData,
+    queue.resultsData,
+    queue.settings,
+    queue.selectedImage,
+  ])
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: any) => {
+      const isMod = e.ctrlKey || e.metaKey
+
+      if (isMod) {
+        if (e.key === "=" || e.key === "+") {
+          e.preventDefault()
+          handleZoomIn()
+        } else if (e.key === "-") {
+          e.preventDefault()
+          handleZoomOut()
+        } else if (e.key === "0") {
+          e.preventDefault()
+          handleZoomReset()
+        } else if (e.key === "Enter") {
+          e.preventDefault()
+          process()
+        }
+      }
+    }
+
+    globalThis.addEventListener("keydown", handleKeyDown)
+    return () => globalThis.removeEventListener("keydown", handleKeyDown)
+  }, [handleZoomIn, handleZoomOut, handleZoomReset, process])
 
   // Derived
   const canDownload =
     activeTool === "upscaler"
       ? !!upscaledData
       : activeTool === "colorizer"
-        ? !!colorizedData
-        : !!queue.resultsData.find((r) => r.name === queue.selectedImage)
+      ? !!colorizedData
+      : !!queue.resultsData.find((r) => r.name === queue.selectedImage)
 
   const accentColor = TOOL_ACCENTS[activeTool]
   const bgImage = queue.imageData || queue.resultData

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.2] - 2025-05-15
+
+### ✨ Added
+
+- 🎨 **Palette**: Added global keyboard shortcuts for editor controls.
+  - `Ctrl/Cmd +` or `Ctrl/Cmd =`: Zoom In
+  - `Ctrl/Cmd -`: Zoom Out
+  - `Ctrl/Cmd 0`: Reset Zoom
+  - `Ctrl/Cmd Enter`: Process all images in queue
+- 🎨 **Palette**: Added keyboard shortcut hints to toolbar tooltips for better discoverability.
+
+---
+
 ## [1.1.1] - Some Stability Fixes
 
 ### 🐛 Fixed


### PR DESCRIPTION
Implemented keyboard shortcuts in the editor for zooming and batch processing. These changes improve accessibility and power-user efficiency. Tooltips have been updated to display the associated shortcuts.
- Zoom In: `Ctrl/Cmd +` or `Ctrl/Cmd =`
- Zoom Out: `Ctrl/Cmd -`
- Reset Zoom: `Ctrl/Cmd 0`
- Batch Process: `Ctrl/Cmd Enter`

Also documented the changes in CHANGELOG.md and updated my UX journal.

---
*PR created automatically by Jules for task [7213288301332447727](https://jules.google.com/task/7213288301332447727) started by @yossTheDev*