### PR TITLE
🎨 Palette: Add Ctrl+S keyboard shortcut for image downloads

### DIFF
--- a/components/editor/components/EditorToolbar.tsx
+++ b/components/editor/components/EditorToolbar.tsx
@@ -85,7 +85,7 @@ export const EditorToolbar = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Download all images</p>
+            <p>Download all images (Ctrl + S)</p>
           </TooltipContent>
         </Tooltip>
 

--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -29,7 +29,7 @@ import type { ActiveTool, ModelKey, UpscalerModelKey } from "./types"
 
 const VALID_TOOLS: ActiveTool[] = ["remover", "upscaler", "colorizer"]
 const VALID_MODELS = Object.keys(MODELS) as ModelKey[]
-const APP_VERSION = "1.1.2"
+const APP_VERSION = "1.1.3"
 
 interface EditorProps {
   initialTool?: ActiveTool
@@ -460,13 +460,16 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
         } else if (e.key === "Enter") {
           e.preventDefault()
           process()
+        } else if (e.key === "s" || e.key === "S") {
+          e.preventDefault()
+          handleDownload()
         }
       }
     }
 
     globalThis.addEventListener("keydown", handleKeyDown)
     return () => globalThis.removeEventListener("keydown", handleKeyDown)
-  }, [handleZoomIn, handleZoomOut, handleZoomReset, process])
+  }, [handleZoomIn, handleZoomOut, handleZoomReset, process, handleDownload])
 
   return (
     <div

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.3] - 2026-04-27
+### Added
+- 🎨 **Palette**: Added Ctrl+S keyboard shortcut for downloading images in the editor.
+- [Technical note: Added Ctrl/Cmd + S shortcut support and updated toolbar tooltip hints].
+
 ## [1.1.2] - 2025-03-24
 ### Added
 - 🎨 **Palette**: Added keyboard shortcuts and tooltip hints for core editor actions.


### PR DESCRIPTION
Implemented a micro-UX improvement by adding the standard `Ctrl+S` (and `Cmd+S`) keyboard shortcut for downloading processed images in the editor. 

Key changes:
- Added `Ctrl+S` / `Cmd+S` detection to the global `keydown` listener in `components/editor/index.tsx`.
- Updated the `EditorToolbar` download button tooltip to include the `(Ctrl + S)` hint.
- Incremented the `APP_VERSION` and updated `public/CHANGELOG.md` to version `1.1.3`.
- Verified the implementation visually via Playwright and ensured the repository remains clean of build artifacts.

---
*PR created automatically by Jules for task [2129770464472683921](https://jules.google.com/task/2129770464472683921) started by @yossTheDev*