### PR TITLE
🎨 Palette: UX and Accessibility improvements for Removerized

### DIFF
--- a/components/editor/components/EditorToolbar.tsx
+++ b/components/editor/components/EditorToolbar.tsx
@@ -11,6 +11,7 @@ import {
 
 interface EditorToolbarProps {
   canDownload: boolean
+  canProcess: boolean
   onProcess: () => void
   onDownload: () => void
   accentColor: string
@@ -22,6 +23,7 @@ interface EditorToolbarProps {
 
 export const EditorToolbar = ({
   canDownload,
+  canProcess,
   onProcess,
   onDownload,
   accentColor,
@@ -51,17 +53,20 @@ export const EditorToolbar = ({
         {/* Batch process queue */}
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              onClick={onProcess}
-              size="icon"
-              variant="ghost"
-              aria-label="Process all images in queue"
-              className={cn(
-                "size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
-              )}
-            >
-              <LoaderIcon className="size-4" />
-            </Button>
+            <div className="flex">
+              <Button
+                onClick={onProcess}
+                disabled={!canProcess}
+                size="icon"
+                variant="ghost"
+                aria-label="Process all images in queue"
+                className={cn(
+                  "size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 disabled:opacity-20"
+                )}
+              >
+                <LoaderIcon className="size-4" />
+              </Button>
+            </div>
           </TooltipTrigger>
           <TooltipContent>
             <p>Process all images (Ctrl + Enter)</p>
@@ -73,19 +78,21 @@ export const EditorToolbar = ({
         {/* Download result */}
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              disabled={!canDownload}
-              onClick={onDownload}
-              size="icon"
-              variant="ghost"
-              aria-label="Download result"
-              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white disabled:opacity-20"
-            >
-              <Download className="size-4" />
-            </Button>
+            <div className="flex">
+              <Button
+                disabled={!canDownload}
+                onClick={onDownload}
+                size="icon"
+                variant="ghost"
+                aria-label="Download result"
+                className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20 disabled:opacity-20"
+              >
+                <Download className="size-4" />
+              </Button>
+            </div>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Download all images</p>
+            <p>Download all images (Ctrl + S)</p>
           </TooltipContent>
         </Tooltip>
 
@@ -99,7 +106,7 @@ export const EditorToolbar = ({
               size="icon"
               variant="ghost"
               aria-label="Zoom in"
-              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
+              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
             >
               <ZoomIn className="size-4" />
             </Button>
@@ -118,11 +125,14 @@ export const EditorToolbar = ({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              onClick={onZoomOut}
+              onClick={e => {
+                e.preventDefault()
+                onZoomOut()
+              }}
               size="icon"
               variant="ghost"
               aria-label="Zoom out"
-              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
+              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
             >
               <ZoomOut className="size-4" />
             </Button>
@@ -140,7 +150,7 @@ export const EditorToolbar = ({
               size="icon"
               variant="ghost"
               aria-label="Reset zoom"
-              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white"
+              className="size-8 rounded-xl text-white/50 transition-all hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
             >
               <ScanEye className="size-4" />
             </Button>

--- a/components/editor/components/panels/EditorRightPanel.tsx
+++ b/components/editor/components/panels/EditorRightPanel.tsx
@@ -118,7 +118,7 @@ export const EditorRightPanel = ({
               key={key}
               onClick={() => onToolChange(key)}
               className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-medium transition-all duration-200"
+                "flex flex-1 items-center justify-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
               )}
               style={
                 activeTool === key

--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -29,7 +29,7 @@ import type { ActiveTool, ModelKey, UpscalerModelKey } from "./types"
 
 const VALID_TOOLS: ActiveTool[] = ["remover", "upscaler", "colorizer"]
 const VALID_MODELS = Object.keys(MODELS) as ModelKey[]
-const APP_VERSION = "1.1.2"
+const APP_VERSION = "1.1.3"
 
 interface EditorProps {
   initialTool?: ActiveTool
@@ -460,13 +460,16 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
         } else if (e.key === "Enter") {
           e.preventDefault()
           process()
+        } else if (e.key === "s" || e.key === "S") {
+          e.preventDefault()
+          handleDownload()
         }
       }
     }
 
     globalThis.addEventListener("keydown", handleKeyDown)
     return () => globalThis.removeEventListener("keydown", handleKeyDown)
-  }, [handleZoomIn, handleZoomOut, handleZoomReset, process])
+  }, [handleZoomIn, handleZoomOut, handleZoomReset, process, handleDownload])
 
   return (
     <div
@@ -536,6 +539,7 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
         />
         <EditorToolbar
           canDownload={canDownload}
+          canProcess={queue.files.length > 0}
           onProcess={process}
           onDownload={handleDownload}
           accentColor={accentColor}

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.3] - 2025-03-25
+### Added
+- 🎨 **Palette**: Added `Ctrl/Cmd + S` keyboard shortcut for image downloads.
+- 🎨 **Palette**: Added shortcut hints to tooltips in the editor toolbar for better discoverability.
+
+### Improved
+- 🎨 **Palette**: Enhanced accessibility by adding visible focus rings to toolbar buttons and tool switcher tabs.
+- 🎨 **Palette**: Improved toolbar state management by disabling the process button when the queue is empty, with functional tooltips for disabled states.
+
 ## [1.1.2] - 2025-03-24
 ### Added
 - 🎨 **Palette**: Added keyboard shortcuts and tooltip hints for core editor actions.


### PR DESCRIPTION
This PR introduces a series of micro-UX and accessibility improvements to the Removerized editor.

Key changes:
- **Keyboard Shortcuts**: Added `Ctrl+S` (Windows/Linux) and `Cmd+S` (macOS) to trigger the image download action.
- **Visual Feedback**: Enhanced tooltips to include shortcut hints, such as "Download Results (Ctrl + S)", helping users discover keyboard-driven workflows.
- **Accessibility**: Added `focus-visible:ring-2` styles to toolbar buttons and the right-panel tool switcher tabs. This ensures keyboard users can clearly see which element is focused.
- **State Handling**: The "Process" button is now disabled when the image queue is empty. To maintain UX clarity, the button is wrapped in a container that allows the Radix UI tooltip to remain functional even in the disabled state.
- **Consistency**: Updated the internal `APP_VERSION` and `public/CHANGELOG.md` to reflect version `1.1.3`.

Verified via `yarn typecheck`, `yarn next build --webpack`, and Playwright functional tests.

---
*PR created automatically by Jules for task [4324407192157544517](https://jules.google.com/task/4324407192157544517) started by @yossTheDev*