### PR TITLE
🎨 Palette: Add Ctrl+S shortcut and improve focus visibility

### DIFF
--- a/components/editor/components/EditorToolbar.tsx
+++ b/components/editor/components/EditorToolbar.tsx
@@ -85,7 +85,7 @@ export const EditorToolbar = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Download all images</p>
+            <p>Download all images (Ctrl + S)</p>
           </TooltipContent>
         </Tooltip>
 

--- a/components/editor/components/panels/EditorRightPanel.tsx
+++ b/components/editor/components/panels/EditorRightPanel.tsx
@@ -118,7 +118,7 @@ export const EditorRightPanel = ({
               key={key}
               onClick={() => onToolChange(key)}
               className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-medium transition-all duration-200"
+                "flex flex-1 items-center justify-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
               )}
               style={
                 activeTool === key
@@ -157,7 +157,7 @@ export const EditorRightPanel = ({
               <>
                 <button
                   onClick={() => setModelDialogOpen(true)}
-                  className="group flex w-full items-center justify-between rounded-xl border border-white/[0.07] bg-white/[0.03] px-3.5 py-3 text-left transition-all duration-200 hover:border-white/[0.14] hover:bg-white/[0.06]"
+                  className="group flex w-full items-center justify-between rounded-xl border border-white/[0.07] bg-white/[0.03] px-3.5 py-3 text-left transition-all duration-200 hover:border-white/[0.14] hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
                 >
                   <div className="flex flex-col gap-0.5">
                     <span className="text-[9px] font-semibold uppercase tracking-[0.15em] text-white/30">

--- a/components/editor/components/panels/RemoverTab.tsx
+++ b/components/editor/components/panels/RemoverTab.tsx
@@ -52,7 +52,7 @@ export const RemoverTab = ({
             aria-checked={applyBgColor}
             onClick={onToggleBgColor}
             className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none"
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
             )}
             style={{
               backgroundColor: applyBgColor

--- a/components/editor/index.tsx
+++ b/components/editor/index.tsx
@@ -29,7 +29,7 @@ import type { ActiveTool, ModelKey, UpscalerModelKey } from "./types"
 
 const VALID_TOOLS: ActiveTool[] = ["remover", "upscaler", "colorizer"]
 const VALID_MODELS = Object.keys(MODELS) as ModelKey[]
-const APP_VERSION = "1.1.2"
+const APP_VERSION = "1.1.3"
 
 interface EditorProps {
   initialTool?: ActiveTool
@@ -460,13 +460,16 @@ export const Editor = ({ initialTool = "remover" }: EditorProps) => {
         } else if (e.key === "Enter") {
           e.preventDefault()
           process()
+        } else if (e.key === "s" || e.key === "S") {
+          e.preventDefault()
+          handleDownload()
         }
       }
     }
 
     globalThis.addEventListener("keydown", handleKeyDown)
     return () => globalThis.removeEventListener("keydown", handleKeyDown)
-  }, [handleZoomIn, handleZoomOut, handleZoomReset, process])
+  }, [handleZoomIn, handleZoomOut, handleZoomReset, process, handleDownload])
 
   return (
     <div

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [1.1.3] - 2025-05-14
+### Added
+- 🎨 **Palette**: Added Ctrl+S keyboard shortcut for downloading results.
+- 🎨 **Palette**: Enhanced focus visibility for core interactive elements (tab switcher, model selector, background toggle).
+- [Technical note: Updated Tooltip hints and added focus-visible rings for better accessibility].
+
 ## [1.1.2] - 2025-03-24
 ### Added
 - 🎨 **Palette**: Added keyboard shortcuts and tooltip hints for core editor actions.


### PR DESCRIPTION
This PR implements several micro-UX improvements to the editor:

1. **Keyboard Shortcuts**: Added `Ctrl + S` (and `Cmd + S`) to trigger the download of processed images. This follows the existing pattern for shortcuts like `Ctrl + Enter` for batch processing.
2. **Discoverability**: Updated the download button's tooltip to include the new keyboard shortcut hint `(Ctrl + S)`.
3. **Accessibility**: Added visible focus rings (`focus-visible:ring-2`) to core interactive elements that previously lacked clear focus states, specifically:
   - Tool tab switcher buttons
   - AI Model selector button
   - Solid Background toggle switch
4. **Versioning**: Incremented the application version to `1.1.3` and added a corresponding entry in `public/CHANGELOG.md`.

These changes make the editor more efficient for power users and more accessible for keyboard navigation.

---
*PR created automatically by Jules for task [5348803213404841561](https://jules.google.com/task/5348803213404841561) started by @yossTheDev*